### PR TITLE
Fix rubocop warnings and stop using inventory collection secondary refs

### DIFF
--- a/app/models/manageiq/providers/hawkular/inventory/parser/middleware_domain_servers.rb
+++ b/app/models/manageiq/providers/hawkular/inventory/parser/middleware_domain_servers.rb
@@ -26,8 +26,7 @@ module ManageIQ::Providers::Hawkular::Inventory::Parser
       server_group_name = server.config['Server Group']
       unless server_group_name.nil?
         inventory_object.middleware_server_group =
-          persister.middleware_server_groups
-                   .lazy_find_by({:feed => server.feed, :name => server_group_name}, {:ref => :by_feed_and_name})
+          persister.find_server_group_by_feed_and_name(server.feed, server_group_name)
       end
     end
 

--- a/app/models/manageiq/providers/hawkular/inventory/parser/middleware_domains.rb
+++ b/app/models/manageiq/providers/hawkular/inventory/parser/middleware_domains.rb
@@ -21,8 +21,6 @@ module ManageIQ::Providers::Hawkular::Inventory::Parser
           fetch_server_groups(parsed_domain, host_controller)
         end
       end
-
-      persister.middleware_server_groups.rehash_secondary_indexes
     end
 
     def fetch_server_groups(parsed_domain, host_controller)

--- a/app/models/manageiq/providers/hawkular/inventory/parser/middleware_server_entities.rb
+++ b/app/models/manageiq/providers/hawkular/inventory/parser/middleware_server_entities.rb
@@ -37,7 +37,7 @@ module ManageIQ::Providers::Hawkular::Inventory::Parser
     end
 
     def process_server_entity(server, entity)
-      if %w[Deployment SubDeployment].include?(entity.type.id)
+      if %w(Deployment SubDeployment).include?(entity.type.id)
         inventory_object = persister.middleware_deployments.find_or_build(entity.id)
         parse_deployment(entity, inventory_object)
       elsif entity.type.id == 'Datasource'

--- a/app/models/manageiq/providers/hawkular/inventory/persister/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/inventory/persister/middleware_manager.rb
@@ -3,10 +3,26 @@ module ManageIQ::Providers
     include ManagerRefresh::Inventory::MiddlewareManager
 
     has_middleware_manager_domains
-    has_middleware_manager_server_groups(:secondary_refs => {:by_feed_and_name => %i[feed name]})
+    has_middleware_manager_server_groups
     has_middleware_manager_servers
     has_middleware_manager_deployments
     has_middleware_manager_datasources
     has_middleware_manager_messagings
+
+    def find_server_group_by_feed_and_name(feed, group_name)
+      @server_groups_idx ||= build_server_group_index
+      @server_groups_idx.fetch_path(feed, group_name)
+    end
+
+    protected
+
+    def build_server_group_index
+      idx = {}
+      middleware_server_groups.each do |group|
+        idx.store_path(group.feed, group.name, group)
+      end
+
+      idx
+    end
   end
 end

--- a/spec/models/manageiq/providers/hawkular/inventory/parser/middleware_domains_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/inventory/parser/middleware_domains_spec.rb
@@ -57,7 +57,7 @@ describe ManageIQ::Providers::Hawkular::Inventory::Parser::MiddlewareDomains do
         allow(collector).to receive(:resource_tree).with('hc1').and_return(controller_with_tree)
         allow(collector).to receive(:domains).and_return([controller_with_tree.children.first])
         allow(collector).to receive(:raw_availability_data)
-          .with(%w[host_master_avail], hash_including(:order => 'DESC'))
+          .with(%w(host_master_avail), hash_including(:order => 'DESC'))
           .and_return([metric_data])
       end
   end
@@ -125,7 +125,7 @@ describe ManageIQ::Providers::Hawkular::Inventory::Parser::MiddlewareDomains do
 
   it 'assigns unknown status to a domain with a missing metric' do
     allow(collector).to receive(:raw_availability_data)
-      .with(%w[host_master_avail], hash_including(:order => 'DESC'))
+      .with(%w(host_master_avail), hash_including(:order => 'DESC'))
       .and_return([])
 
     parser.parse

--- a/spec/models/manageiq/providers/hawkular/inventory/parser/middleware_server_entities_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/inventory/parser/middleware_server_entities_spec.rb
@@ -113,7 +113,7 @@ describe ManageIQ::Providers::Hawkular::Inventory::Parser::MiddlewareServerEntit
     before do
       allow(collector).to receive(:deployments).and_return(eap_with_tree.children)
       allow(collector).to receive(:raw_availability_data)
-        .with(%w[deploy1], hash_including(:order => 'DESC'))
+        .with(%w(deploy1), hash_including(:order => 'DESC'))
         .and_return([metric_data])
     end
 
@@ -157,7 +157,7 @@ describe ManageIQ::Providers::Hawkular::Inventory::Parser::MiddlewareServerEntit
 
     it 'assigns unknown status to a deployment with a missing metric' do
       allow(collector).to receive(:raw_availability_data)
-        .with(%w[deploy1], hash_including(:order => 'DESC'))
+        .with(%w(deploy1), hash_including(:order => 'DESC'))
         .and_return([])
 
       parser.parse

--- a/spec/models/manageiq/providers/hawkular/inventory/parser/middleware_servers_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/inventory/parser/middleware_servers_spec.rb
@@ -67,7 +67,7 @@ describe ManageIQ::Providers::Hawkular::Inventory::Parser::MiddlewareServers do
         allow(collector).to receive(:agents).and_return([agent_resource])
         allow(collector).to receive(:eaps).and_return([eap_resource])
         allow(collector).to receive(:raw_availability_data)
-          .with(%w[server1_avail_metric], hash_including(:order => 'DESC'))
+          .with(%w(server1_avail_metric), hash_including(:order => 'DESC'))
           .and_return([metric_data])
       end
   end
@@ -121,7 +121,7 @@ describe ManageIQ::Providers::Hawkular::Inventory::Parser::MiddlewareServers do
 
   it 'assigns unknown status to a server with a missing metric' do
     allow(collector).to receive(:raw_availability_data)
-      .with(%w[server1_avail_metric], hash_including(:order => 'DESC'))
+      .with(%w(server1_avail_metric), hash_including(:order => 'DESC'))
       .and_return([])
 
     parser.parse


### PR DESCRIPTION
Secondary references in inventory collection are experimental for now. Stop using them and use an index in the persister to link servers with server groups.